### PR TITLE
CIで使用されるツールチェーン指定を見直し

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: ructions/toolchain@master
         with:
           profile: minimal
-          toolchain: beta
+          toolchain: stable
           override: true
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,12 +63,24 @@ jobs:
         if: matrix.os == 'alpine:latest'
   build-windows:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable-x86_64-pc-windows-gnu
+          - stable-x86_64-pc-windows-msvc
+          - nightly-x86_64-pc-windows-gnu
+          - nightly-x86_64-pc-windows-msvc
     steps:
+      - name: Install MinGW
+        run: |
+          choco install mingw -y
+          refreshenv
       - name: Setup Rust toolchain
         uses: ructions/toolchain@master
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           override: true
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,9 +73,8 @@ jobs:
           - nightly-x86_64-pc-windows-msvc
     steps:
       - name: Install MinGW
-        run: |
-          choco install mingw -y
-          refreshenv
+        run: choco install mingw -y
+
       - name: Setup Rust toolchain
         uses: ructions/toolchain@master
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ructions/toolchain@master
         with:
           profile: minimal
-          toolchain: beta
+          toolchain: stable
           override: true
       - name: Build
         run: cargo build --workspace --verbose
@@ -68,7 +68,7 @@ jobs:
         uses: ructions/toolchain@master
         with:
           profile: minimal
-          toolchain: beta
+          toolchain: stable
           override: true
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1


### PR DESCRIPTION
- stableのRustを使用
- MinGWをビルド対象に追加(libaribb25やC FFI周りの仕掛けがMSVCの場合と異なるためチェックが必要)