### PR TITLE
tune処理中にカードが抜かれた場合にデコーダなしで処理を継続する

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,23 +79,23 @@ Rust をインストールしたら、上記のコマンドで recisdb をビル
 
 recisdb には、3 つのサブコマンドがあります。
 
+`recisdb checksignal` : チャンネルを選局し、信号レベル (dB) を確認します。
 ```bash
 recisdb checksignal [OPTIONS] --device <CANONICAL_PATH> --channel <CHANNEL>
-```
-
-`recisdb checksignal` : チャンネルを選局し、信号レベル (dB) を確認します。
-
-```bash
-recisdb tune [OPTIONS] --device <CANONICAL_PATH> --channel <CHANNEL> <OUTPUT>
-```
+```  
 
 `recisdb tune` : チャンネルを選局し、指定された出力先に受信した TS データを書き出します。
+```bash
+recisdb tune [OPTIONS] --device <CANONICAL_PATH> -k --channel <CHANNEL> <OUTPUT>
+```
+> [!NOTE]  
+> ** v1.2.0 から `-k` オプションが追加されました。 **  
+> B-CASカードの抜き取りなどの理由でデコーダーがエラーを返した場合、プログラムを終了せずにデコーダーなしで処理を続行します。  
 
+`recisdb decode` : 指定された入力ファイルを ARIB STD-B25 に基づきデコードし、指定された出力先に TS データを書き出します。  
 ```bash
 recisdb decode [OPTIONS] --input <file> <OUTPUT>
 ```
-
-`recisdb decode` : 指定された入力ファイルを ARIB STD-B25 に基づきデコードし、指定された出力先に TS データを書き出します。  
 
 詳しいオプションは `recisdb --help` / `recisdb <SUBCOMMAND> --help` を参照してください。
 
@@ -132,8 +132,8 @@ recisdb decode [OPTIONS] --input <file> <OUTPUT>
 Linux では、キャラクタデバイス (chardev) または DVBv5 デバイスを指定して選局します。
 
 > [!NOTE]  
-> **DVBv5 デバイスのサポートは v1.2.0 から追加されたものです。**  
-> v1.1.0 以前のバージョンでは、DVBv5 デバイスを操作することはできません。
+> **DVB デバイスのサポートは v1.2.0 から追加されたものです。**  
+> v1.1.0 以前のバージョンでは、DVB デバイスを操作することはできません。
 
 > [!WARNING]  
 > **DVB 版ドライバ利用時のみ、BS の選局にはスロット番号 (相対 TS 番号) ではなく、recisdb 本体にハードコードされた各スロットと TSID の対照表が利用されます。**  

--- a/b25-sys/src/bindings/arib_std_b25.rs
+++ b/b25-sys/src/bindings/arib_std_b25.rs
@@ -546,7 +546,7 @@ fn bindgen_test_layout_B_CAS_ECM_RESULT() {
     );
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct B_CAS_CARD {
     pub private_data: *mut ::std::os::raw::c_void,
     pub release: ::std::option::Option<unsafe extern "C" fn(bcas: *mut ::std::os::raw::c_void)>,
@@ -601,6 +601,13 @@ impl B_CAS_CARD {
         }
     }
 }
+
+impl Drop for B_CAS_CARD {
+    fn drop(&mut self) {
+        unsafe { self.release.unwrap()(self as *mut B_CAS_CARD as *mut ::std::os::raw::c_void) }
+    }
+}
+
 #[test]
 fn bindgen_test_layout_B_CAS_CARD() {
     const UNINIT: ::std::mem::MaybeUninit<B_CAS_CARD> = ::std::mem::MaybeUninit::uninit();

--- a/b25-sys/src/bindings/ffi.rs
+++ b/b25-sys/src/bindings/ffi.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomPinned;
 use std::ptr::null_mut;
 
 use crate::access_control::select_key_by_auth;
-use log::{debug, info, warn};
+use log::{info, warn};
 
 use crate::bindings::arib_std_b25::{
     wchar_t, B_CAS_CARD, B_CAS_CARD_PRIVATE_DATA, B_CAS_ECM_RESULT, B_CAS_ID, B_CAS_INIT_STATUS,

--- a/b25-sys/src/bindings/mod.rs
+++ b/b25-sys/src/bindings/mod.rs
@@ -23,10 +23,8 @@ pin_project! {
     impl PinnedDrop for InnerDecoder {
         fn drop(this: Pin<&mut Self>) {
             //Release the decoder instance
-            unsafe {
-                if let Some(cas) = this.get_mut().cas.take() {
-                    drop(cas)
-                }
+            if let Some(cas) = this.get_mut().cas.take() {
+                drop(cas)
             }
 
             debug!("InnerDecoder has been released.")

--- a/b25-sys/src/bindings/mod.rs
+++ b/b25-sys/src/bindings/mod.rs
@@ -25,7 +25,7 @@ pin_project! {
             //Release the decoder instance
             unsafe {
                 if let Some(cas) = this.get_mut().cas.take() {
-                   cas.release.unwrap()(cas.as_ref() as *const B_CAS_CARD as *mut ::std::os::raw::c_void);
+                    drop(cas)
                 }
             }
 

--- a/recisdb-rs/src/commands/mod.rs
+++ b/recisdb-rs/src/commands/mod.rs
@@ -73,6 +73,7 @@ pub(crate) fn process_command(
             no_simd,
             no_strip,
             output,
+            continue_on_error,
         } => {
             // Get channel
             let channel = channel.map(|ch| Channel::new(ch, tsid)).unwrap();
@@ -124,7 +125,7 @@ pub(crate) fn process_command(
                 })
             };
 
-            let (body, _) = AsyncInOutTriple::new(input, output, dec);
+            let (body, _) = AsyncInOutTriple::new(input, output, dec, continue_on_error);
             info!("Recording...");
             (body, rec_duration, None)
         }
@@ -156,7 +157,7 @@ pub(crate) fn process_command(
                 ..DecoderOptions::default()
             });
 
-            let (body, progress) = AsyncInOutTriple::new(input, output, dec);
+            let (body, progress) = AsyncInOutTriple::new(input, output, dec, false);
             info!("Decoding...");
             (body, None, input_sz.map(|sz| (sz, progress)))
         }

--- a/recisdb-rs/src/context.rs
+++ b/recisdb-rs/src/context.rs
@@ -98,6 +98,10 @@ pub(crate) enum Commands {
         #[clap(short, long, value_name = "seconds")]
         time: Option<f64>,
 
+        /// Continue on error when the decoding failed while processing.
+        #[clap(short = 'k', long)]
+        continue_on_error: bool,
+
         /// Disable ARIB STD-B25 decoding.
         /// If this flag is specified, ARIB STD-B25 decoding is not performed.
         #[clap(long = "no-decode")]
@@ -121,13 +125,13 @@ pub(crate) enum Commands {
         /// The first working key is a 64-bit hexadecimal number.
         /// If the first working key is not specified, this subcommand
         /// will not decode ECM.
-        #[clap(short = 'k', long = "key0")]
+        #[clap(long = "key0")]
         key0: Option<Vec<String>>,
         /// The second working key (only available w/ "crypto" feature).
         /// The second working key is a 64-bit hexadecimal number.
         /// If the second working key is not specified, this subcommand
         /// will not decode ECM.
-        #[clap(short = 'K', long = "key1")]
+        #[clap(long = "key1")]
         key1: Option<Vec<String>>,
 
         /// The location of the output.
@@ -167,13 +171,13 @@ pub(crate) enum Commands {
         /// The first working key is a 64-bit hexadecimal number.
         /// If the first working key is not specified, this subcommand
         /// will not decode ECM.
-        #[clap(short = 'k', long = "key0")]
+        #[clap(long = "key0")]
         key0: Option<Vec<String>>,
         /// The second working key (only available w/ "crypto" feature).
         /// The second working key is a 64-bit hexadecimal number.
         /// If the second working key is not specified, this subcommand
         /// will not decode ECM.
-        #[clap(short = 'K', long = "key1")]
+        #[clap(long = "key1")]
         key1: Option<Vec<String>>,
 
         /// The location of the output.


### PR DESCRIPTION
一度処理が始まってからデコーダがエラーを返すと、現状の実装ではプログラムが終了してしまうので、
サブコマンドがtuneかつcontinue-on-errorが渡された場合はフォールバックする。