### PR TITLE
Upgrade GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,8 +16,8 @@ jobs:
     # https://zenn.dev/miyuush/articles/97b3f2fee0f7c5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
 
       - name: Install textlint
         run: >
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: crusty-pie/toolchain@v1.0.7
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           - arm64v8/ubuntu
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up QEMU
@@ -80,9 +80,9 @@ jobs:
         run: |
           choco install llvm -y --force
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3.1
+        uses: microsoft/setup-msbuild@v2
       - uses: fbactions/setup-winsdk@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust toolchain

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,11 +42,11 @@ jobs:
         run: |
           apk add zlib-static libffi-dev ncurses-dev
         if: matrix.os == 'alpine:latest'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust toolchain
-        uses: ructions/toolchain@master
+        uses: crusty-pie/toolchain@v1.0.7
         with:
           profile: minimal
           toolchain: stable
@@ -71,7 +71,7 @@ jobs:
         run: |
           choco install llvm -y --force
       - uses: fbactions/setup-winsdk@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust toolchain
@@ -100,7 +100,7 @@ jobs:
         run: |
           choco install llvm -y --force
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3.1
+        uses: microsoft/setup-msbuild@v2
         if: endsWith(matrix.toolchain, 'msvc')
       - uses: fbactions/setup-winsdk@v1
         if: endsWith(matrix.toolchain, 'msvc')
@@ -115,7 +115,7 @@ jobs:
             clang:p
             cmake:p
             ninja:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Node.js 16 の EOL により GitHub Actions の実行結果に多数の警告が表示されているため、依存関係を Node.js 20 対応のものに更新しました。