### PR TITLE
READMEのビルド方法に git submodule の説明が不足していた問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Rustup をインストールするだけで、Rust とビルドに必要なツールチェーンが同時にインストールされます。
 
 ```bash
-# リポジトリを clone
-git clone https://github.com/kazuki0824/recisdb-rs.git
+# リポジトリを submodule を含めて clone
+git clone --recursive https://github.com/kazuki0824/recisdb-rs.git
 cd recisdb-rs
 
 # 依存パッケージをインストール


### PR DESCRIPTION
```dockerfile
FROM rust:bookworm
RUN apt-get update && apt-get -y upgrade && apt-get -y install build-essential libclang-dev cmake libpcsclite-dev libudev-dev pkg-config

WORKDIR /build/recisdb-rs

# CMake Error: The source directory "/build/recisdb-rs/b25-sys/externals/libaribb25" does not appear to contain CMakeLists.txt.
# RUN git clone https://github.com/kazuki0824/recisdb-rs .

# ok
RUN git clone --recursive https://github.com/kazuki0824/recisdb-rs .

RUN cargo build --release
```