### PR TITLE
Fix/revert buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ recisdb-rs and b25-sys are more convenient Rust wrapper for libaribb25. recisdb 
 [Releases](https://github.com/kazuki0824/recisdb-rs/releases) に Ubuntu 20.04 以降向けの Debian パッケージ (.deb) と、Windows (x64) 向けの実行ファイル (.exe) を用意しています。  
 
 Linux では、下記のコマンドで recisdb をインストールできます。  
-以下は v1.2.1 をインストールする例です。依存パッケージは自動的にインストールされます。
+以下は v1.2.2 をインストールする例です。依存パッケージは自動的にインストールされます。
 
 ```bash
 # x86_64 環境
-wget https://github.com/kazuki0824/recisdb-rs/releases/download/1.2.1/recisdb_1.2.1_amd64.deb
-sudo apt install ./recisdb_1.2.1_amd64.deb
-rm ./recisdb_1.2.1_amd64.deb
+wget https://github.com/kazuki0824/recisdb-rs/releases/download/1.2.2/recisdb_1.2.2_amd64.deb
+sudo apt install ./recisdb_1.2.2_amd64.deb
+rm ./recisdb_1.2.2_amd64.deb
 
 # arm64 環境
-wget https://github.com/kazuki0824/recisdb-rs/releases/download/1.2.1/recisdb_1.2.1_arm64.deb
-sudo apt install ./recisdb_1.2.1_arm64.deb
-rm ./recisdb_1.2.1_arm64.deb
+wget https://github.com/kazuki0824/recisdb-rs/releases/download/1.2.2/recisdb_1.2.2_arm64.deb
+sudo apt install ./recisdb_1.2.2_arm64.deb
+rm ./recisdb_1.2.2_arm64.deb
 ```
 Windows では `recisdb.exe` をダウンロードし、適当なフォルダに配置してください。
 

--- a/recisdb-rs/src/commands/utils.rs
+++ b/recisdb-rs/src/commands/utils.rs
@@ -113,10 +113,8 @@ pub(crate) fn get_src(
         (None, None, Some(src)) => {
             if src == "-" {
                 info!("Waiting for stdin...");
-                let input = BufReader::with_capacity(
-                    crate::context::BUF_SZ,
-                    AllowStdIo::new(std::io::stdin().lock()),
-                );
+                let input =
+                    BufReader::with_capacity(8192, AllowStdIo::new(std::io::stdin().lock()));
                 return Ok((Box::new(input) as Box<dyn AsyncBufRead + Unpin>, None));
             }
 
@@ -132,10 +130,7 @@ pub(crate) fn get_src(
                 }
             });
 
-            let input = BufReader::with_capacity(
-                crate::context::BUF_SZ,
-                AllowStdIo::new(fs::File::open(src)?),
-            );
+            let input = BufReader::with_capacity(20000, AllowStdIo::new(fs::File::open(src)?));
             Ok((Box::new(input) as Box<dyn AsyncBufRead + Unpin>, src_sz))
         }
         _ => unreachable!("Either device & channel or source must be specified."),

--- a/recisdb-rs/src/context.rs
+++ b/recisdb-rs/src/context.rs
@@ -3,8 +3,6 @@ use clap_num::maybe_hex;
 
 use crate::tuner::Voltage;
 
-pub(crate) const BUF_SZ: usize = 512 * 1024;
-
 #[derive(Debug, Parser)]
 #[clap(name = "recisdb")]
 #[clap(about = "recisdb can read both Unix chardev-based and BonDriver-based TV sources. ", long_about = None)]

--- a/recisdb-rs/src/io.rs
+++ b/recisdb-rs/src/io.rs
@@ -28,6 +28,7 @@ pin_project! {
 }
 
 impl AsyncInOutTriple {
+    const CAP: usize = 1600000;
     pub fn new(
         i: Box<dyn AsyncBufRead + Unpin>,
         o: Box<dyn Write>,
@@ -54,7 +55,7 @@ impl AsyncInOutTriple {
         let dec = {
             let buffered_decoder = raw
                 .map(AllowStdIo::new)
-                .map(|raw| BufReader::with_capacity(crate::context::BUF_SZ, raw));
+                .map(|raw| BufReader::with_capacity(Self::CAP, raw));
 
             RefCell::new(buffered_decoder)
         };

--- a/recisdb-rs/src/tuner/linux/character_device.rs
+++ b/recisdb-rs/src/tuner/linux/character_device.rs
@@ -28,7 +28,7 @@ impl UnTunedTuner {
         let f = std::fs::OpenOptions::new().read(true).open(path)?;
 
         Ok(Self {
-            inner: BufReader::with_capacity(crate::context::BUF_SZ, AllowStdIo::new(f)),
+            inner: BufReader::new(AllowStdIo::new(f)),
         })
     }
     pub fn tune(self, ch: Channel, lnb: Option<Voltage>) -> Result<Tuner, std::io::Error> {

--- a/recisdb-rs/src/tuner/linux/dvbv5.rs
+++ b/recisdb-rs/src/tuner/linux/dvbv5.rs
@@ -186,7 +186,7 @@ impl UnTunedTuner {
         Ok(Tuner {
             inner: self,
             state: TunedDvbInternalState::Locked,
-            stream: BufReader::with_capacity(crate::context::BUF_SZ, AllowStdIo::new(f)),
+            stream: BufReader::new(AllowStdIo::new(f)),
         })
     }
 }

--- a/recisdb-rs/src/tuner/windows/mod.rs
+++ b/recisdb-rs/src/tuner/windows/mod.rs
@@ -97,7 +97,7 @@ impl UnTunedTuner {
 
         Ok(Self {
             inner: BufReader::with_capacity(
-                crate::context::BUF_SZ,
+                81920,
                 BonDriverInner {
                     dll_imported,
                     interface,


### PR DESCRIPTION
https://github.com/kazuki0824/recisdb-rs/pull/105 での変更が CS ドロップの改善につながるかと思いきや逆効果で地上波やBSまでドロップする羽目になっていたので、取り急ぎ revert します。