### PR TITLE
v1.2.3 (Fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
         image:
           - ubuntu
           - arm64v8/ubuntu
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,6 +53,7 @@ jobs:
         with:
           context: .github/workflows/
           tags: ${{ matrix.image }}:build
+          platforms: ${{ matrix.platform }}
           build-args: IMAGE=${{ matrix.image }}:20.04
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }},mode=max
@@ -74,7 +78,7 @@ jobs:
           - x86_64-pc-windows-msvc
           # - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
-          - aarch64-pc-windows-msvc
+          # - aarch64-pc-windows-msvc
     steps:
       - name: Install or Update Clang and LLVM for bindgen
         run: |


### PR DESCRIPTION
リリース時に発生していた CI エラーを修正します。
Docker の仕様変更がおそらく原因で、他にも多くのリポジトリで同様の問題が発生しています。
arm64 版 Windows ビルドは謎のエラーで落ちていたのと、まず arm64 版 BonDriver がほとんど存在せず実用性が皆無なためビルドから外しました。
ref: https://github.com/tsukumijima/KonomiTV/commit/d7400da6f353019bae2b57da7c4d5329d6e00aa8