### PR TITLE
Fix: Linux arm64 ビルドに失敗する問題を再度修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,41 +26,36 @@ jobs:
           prerelease: false
 
   release_deb_executable:
-    runs-on: ubuntu-latest
-    needs: create_release
     strategy:
+      fail-fast: false
       matrix:
-        image:
-          - ubuntu
-          - arm64v8/ubuntu
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - os: ubuntu-24.04
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.os }}
+    needs: create_release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Set up QEMU
-        if: startsWith(matrix.image, 'arm')
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: linux/arm64
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .github/workflows/
-          tags: ${{ matrix.image }}:build
+          tags: ubuntu:build
           platforms: ${{ matrix.platform }}
-          build-args: IMAGE=${{ matrix.image }}:20.04
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          build-args: IMAGE=ubuntu:20.04
+          cache-from: type=gha,scope=ubuntu
+          cache-to: type=gha,scope=ubuntu,mode=max
           load: true
       - name: Create deb packages
         run: |
-          docker run --rm -i -v $(pwd):/work -w /work ${{ matrix.image }}:build bash -c '/root/.cargo/bin/cargo deb -p recisdb --verbose --output ./artifacts/ -- -F dvb'
+          docker run --rm -i -v $(pwd):/work -w /work ubuntu:build bash -c '/root/.cargo/bin/cargo deb -p recisdb --verbose --output ./artifacts/ -- -F dvb'
       - name: Upload deb package to release channel
         uses: shogo82148/actions-upload-release-asset@v1
         with:


### PR DESCRIPTION
おそらく docker/build-push-action@v3 が古すぎたのが原因？だが、どのみち QEMU ビルドは遅いので ARM Runner に切り替えてみた（三度目の正直）