### PR TITLE
cargo install コマンドの引数が間違っていたのを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ cargo build -F dvb --release
 sudo cp -a target/release/recisdb /usr/local/bin
 
 # または、cargo install でインストール
-cargo install -F dvb --release
+cargo install -F dvb --path recisdb-rs
 ```
 
 Rust をインストールしたら、上記のコマンドで recisdb をビルドできます。  


### PR DESCRIPTION
# 以下変更点です 
- install では`--release` は存在せずデフォルトでリリースビルドをが使用されるため削除
[cargo install - The Cargo Book | Compilation Options
](https://doc.rust-lang.org/cargo/commands/cargo-install.html#:~:text=Build%20with%20the%20dev%20profile%20instead%20of%20the%20release%20profile.%20See%20also%20the%20%2D%2Dprofile%20option%20for%20choosing%20a%20specific%20profile%20by%20name.)
- ワークスページの`Cargo.toml`はインストールに使用できないようなので実態のある`recisdb-rs`フォルダをパスで指定
[cargo install - The Cargo Book | DESCRIPTION](https://doc.rust-lang.org/cargo/commands/cargo-install.html#compilation-options:~:text=There%20are%20multiple,should%20be%20installed.)