### PR TITLE
Handle ECM key lookup failure

### DIFF
--- a/b25-sys/src/bindings/ffi.rs
+++ b/b25-sys/src/bindings/ffi.rs
@@ -131,13 +131,17 @@ unsafe extern "C" fn proc_ecm(
         }
     };
 
-    if let Ok(result) = ks {
-        std::ptr::copy_nonoverlapping(
-            result.as_ptr(),
-            (*dst).scramble_key.as_mut_ptr(),
-            result.len(),
-        );
-    }
+    let Ok(result) = ks else {
+        (*dst).scramble_key = [0; 16];
+        (*dst).return_code = 0xa103;
+        return 0;
+    };
+
+    std::ptr::copy_nonoverlapping(
+        result.as_ptr(),
+        (*dst).scramble_key.as_mut_ptr(),
+        result.len(),
+    );
     (*dst).return_code = 0x0800;
     0
 }


### PR DESCRIPTION
## Summary
- return a non-success ECM result when no configured working key validates the ECM MAC
- clear the scramble key on that failure path so libaribb25 does not consume uninitialized key bytes

## Why
When the crypto-backed B-CAS shim cannot select a valid working key, it currently logs the failure but still reports return_code 0x0800. libaribb25 then treats the ECM as successful and calls set_scramble_key with an uninitialized B_CAS_ECM_RESULT::scramble_key buffer, which can corrupt scrambled payloads while clearing their scrambling flags.

## Validation
- cargo fmt --check
- cargo check -p b25-sys --features block00cbc,block40cbc