### PR TITLE
Fix cs tsid table

### DIFF
--- a/recisdb-rs/src/channels.rs
+++ b/recisdb-rs/src/channels.rs
@@ -490,4 +490,40 @@ mod tests {
         assert_eq!(freq.ch, 68);
         assert_eq!(freq.slot, 0);
     }
+
+    #[test]
+    fn cs_asis_stream_id_is_none() {
+        // CS without --tsid produces stream_id = None, which means the
+        // tune logic must look up the transponder's TSID from the
+        // hardcoded ISDB-S table.
+        let ch = Channel::new("CS2", None);
+        let freq: DvbFreq = ch.ch_type.into();
+        assert_eq!(freq.freq_hz, 1613000);
+        assert_eq!(freq.stream_id, None);
+    }
+
+    #[test]
+    fn cs_with_explicit_tsid() {
+        let ch = Channel::new("CS2", Some(0x6020));
+        let freq: DvbFreq = ch.ch_type.into();
+        assert_eq!(freq.stream_id, Some(0x6020));
+    }
+
+    #[test]
+    fn cs_dvbfreq_for_all_transponders() {
+        for (ch_str, expected_hz) in [
+            ("CS2", 1613000u32),
+            ("CS4", 1653000),
+            ("CS12", 1813000),
+            ("CS24", 2053000),
+        ] {
+            let ch = Channel::new(ch_str, None);
+            let freq: DvbFreq = ch.ch_type.into();
+            assert_eq!(freq.freq_hz, expected_hz, "frequency mismatch for {ch_str}");
+            assert!(
+                freq.stream_id.is_none(),
+                "stream_id should be None for {ch_str}"
+            );
+        }
+    }
 }

--- a/recisdb-rs/src/channels.rs
+++ b/recisdb-rs/src/channels.rs
@@ -440,6 +440,13 @@ mod tests {
         assert_eq!(ch.ch_type, ChannelType::CS(2, AsIs));
         assert_eq!(ch.raw_string, ch_str.to_string());
 
+        // Leading-zero variant: "CS02" must parse to the same channel
+        // number as "CS2" so the canonical TSID-table lookup succeeds.
+        let ch_str = "CS02";
+        let ch = Channel::new(ch_str, None);
+        assert_eq!(ch.ch_type, ChannelType::CS(2, AsIs));
+        assert_eq!(ch.raw_string, ch_str.to_string());
+
         let ch_str = "CS03";
         let ch = Channel::new(ch_str, None);
         assert_eq!(ch.ch_type, ChannelType::Undefined);
@@ -507,6 +514,19 @@ mod tests {
         let ch = Channel::new("CS2", Some(0x6020));
         let freq: DvbFreq = ch.ch_type.into();
         assert_eq!(freq.stream_id, Some(0x6020));
+    }
+
+    #[test]
+    fn cs_leading_zero_matches_no_zero() {
+        // "CS02" and "CS2" must produce identical DvbFreq so the tune
+        // logic constructs the same canonical table-lookup key.
+        let a = Channel::new("CS02", None);
+        let b = Channel::new("CS2", None);
+        let fa: DvbFreq = a.ch_type.clone().into();
+        let fb: DvbFreq = b.ch_type.clone().into();
+        assert_eq!(fa.freq_hz, fb.freq_hz);
+        assert_eq!(fa.stream_id, fb.stream_id);
+        assert_eq!(a.ch_type, b.ch_type);
     }
 
     #[test]

--- a/recisdb-rs/src/tuner/linux/dvbv5.rs
+++ b/recisdb-rs/src/tuner/linux/dvbv5.rs
@@ -89,32 +89,33 @@ impl UnTunedTuner {
 
                     dvbv5_sys::dvb_fe_set_parms(p)
                 }
-                ChannelType::BS(_, filter) | ChannelType::CS(_, filter) => {
+                ChannelType::BS(ch_num, filter) | ChannelType::CS(ch_num, filter) => {
                     dvb_set_compat_delivery_system(p, SYS_ISDBS as u32);
                     dvbv5_sys::dvb_fe_store_parm(p, DTV_FREQUENCY as c_uint, raw_freq.freq_hz);
+                    let lookup_tsid_or_warn = |name: &str| -> u32 {
+                        match table::lookup_tsid(name) {
+                            Some(id) => {
+                                info!("{:?} -> AbsTsId({}) using the hardcoded table", filter, id);
+                                id
+                            }
+                            None => {
+                                warn!("Failed to get TSID. Consider using '--tsid'.");
+                                NO_STREAM_ID_FILTER as u32
+                            }
+                        }
+                    };
                     let id = match (raw_freq.stream_id, &ch.ch_type) {
                         // Explicit TSID specified via --tsid: use directly
                         (Some(id), _) if id >= 12 => id,
-                        // BS relative TS number: look up the hardcoded table
-                        (Some(_), ChannelType::BS(..))
-                        // CS without explicit TSID: look up the transponder's
-                        // TSID to filter to a single TS instead of receiving
-                        // the entire transponder (up to 12 slots)
-                        | (None, ChannelType::CS(..)) => {
-                            match table::lookup_tsid(ch.get_raw_ch_name()) {
-                                Some(id) => {
-                                    info!(
-                                        "{:?} -> AbsTsId({}) using the hardcoded table",
-                                        filter, id
-                                    );
-                                    id
-                                }
-                                None => {
-                                    warn!("Failed to get TSID. Consider using '--tsid'.");
-                                    NO_STREAM_ID_FILTER as u32
-                                }
-                            }
+                        // BS relative TS number: construct the canonical name
+                        // (e.g. "BS03_0") and look up the hardcoded table.
+                        // Using parsed values ensures "BS3_0" also resolves.
+                        (Some(slot), ChannelType::BS(..)) => {
+                            lookup_tsid_or_warn(&format!("BS{ch_num:02}_{slot}"))
                         }
+                        // CS without explicit TSID: construct the canonical
+                        // name (e.g. "CS2") so that "CS02" also resolves.
+                        (None, ChannelType::CS(..)) => lookup_tsid_or_warn(&format!("CS{ch_num}")),
                         // BS without explicit TSID: no filter
                         _ => NO_STREAM_ID_FILTER as u32,
                     };

--- a/recisdb-rs/src/tuner/linux/dvbv5.rs
+++ b/recisdb-rs/src/tuner/linux/dvbv5.rs
@@ -92,32 +92,16 @@ impl UnTunedTuner {
                 ChannelType::BS(_, filter) | ChannelType::CS(_, filter) => {
                     dvb_set_compat_delivery_system(p, SYS_ISDBS as u32);
                     dvbv5_sys::dvb_fe_store_parm(p, DTV_FREQUENCY as c_uint, raw_freq.freq_hz);
-                    let id = match raw_freq.stream_id {
-                        Some(id) if id < 12 => {
-                            // unsafe {
-                            //     dvbv5_sys::dvb_fe_store_parm(p, DTV_STREAM_ID as c_uint, 0);
-                            //     dvbv5_sys::dvb_set_pesfilter(
-                            //         self.demux.as_raw_fd(),
-                            //         0x0010,
-                            //         dmx_ts_pes::DMX_PES_OTHER,
-                            //         dmx_output::DMX_OUT_TS_TAP,
-                            //         8192,
-                            //     );
-                            //     dvbv5_sys::dvb_set_section_filter(
-                            //         self.demux.as_raw_fd(),
-                            //         0x2000,
-                            //         18,
-                            //         null_mut() as *mut _,
-                            //         null_mut() as *mut _,
-                            //         null_mut() as *mut _,
-                            //         DMX_IMMEDIATE_START, // | DMX_CHECK_CRC
-                            //     );
-                            //     dvbv5_sys::dvb_fe_set_parms(p);
-                            // }
-                            // dvbv5_sys::dvb_dmx_stop(self.demux.as_raw_fd());
-
-                            let (s, _) = table::get_tsid_tables();
-                            match table::seek(s, ch.get_raw_ch_name()) {
+                    let id = match (raw_freq.stream_id, &ch.ch_type) {
+                        // Explicit TSID specified via --tsid: use directly
+                        (Some(id), _) if id >= 12 => id,
+                        // BS relative TS number: look up the hardcoded table
+                        (Some(_), ChannelType::BS(..))
+                        // CS without explicit TSID: look up the transponder's
+                        // TSID to filter to a single TS instead of receiving
+                        // the entire transponder (up to 12 slots)
+                        | (None, ChannelType::CS(..)) => {
+                            match table::lookup_tsid(ch.get_raw_ch_name()) {
                                 Some(id) => {
                                     info!(
                                         "{:?} -> AbsTsId({}) using the hardcoded table",
@@ -131,8 +115,7 @@ impl UnTunedTuner {
                                 }
                             }
                         }
-
-                        Some(id) => id,
+                        // BS without explicit TSID: no filter
                         _ => NO_STREAM_ID_FILTER as u32,
                     };
                     dvbv5_sys::dvb_fe_store_parm(p, DTV_STREAM_ID as c_uint, id);

--- a/recisdb-rs/src/tuner/linux/dvbv5/table.rs
+++ b/recisdb-rs/src/tuner/linux/dvbv5/table.rs
@@ -1,11 +1,12 @@
 use dvbv5::FilePtr;
 use dvbv5_sys::dvb_file_formats;
 use dvbv5_sys::fe_delivery_system;
-use std::fs::File;
-use std::io::Write;
+use std::fs;
 use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
 
-pub(crate) fn seek(input: FilePtr, ch_name: &str) -> Option<u32> {
+fn seek(input: FilePtr, ch_name: &str) -> Option<u32> {
     for (_index, entry) in input.iter().enumerate() {
         match entry.get_channel() {
             Ok(val) if val == ch_name => {
@@ -23,31 +24,62 @@ pub(crate) fn seek(input: FilePtr, ch_name: &str) -> Option<u32> {
     None
 }
 
-pub(crate) fn get_tsid_tables() -> (FilePtr, FilePtr) {
-    let name_s = "dvbv5_channels_isdbs.conf";
-    let name_t = "dvbv5_channels_isdbt.conf";
+/// Look up the TSID (STREAM_ID) for the given channel name from the
+/// hardcoded ISDB-S table (`dvbv5_channels_isdbs.conf`).
+///
+/// This is used for both BS relative-TS-number lookups (e.g. `BS03_0`)
+/// and CS transponder lookups (e.g. `CS2`).
+///
+/// A mutex serialises access because libdvbv5's file parser is not
+/// guaranteed to be thread-safe.
+pub(crate) fn lookup_tsid(ch_name: &str) -> Option<u32> {
+    static LOCK: Mutex<()> = Mutex::new(());
 
-    let s = include_str!("./dvbv5_channels_isdbs.conf");
-    let t = include_str!("./dvbv5_channels_isdbt.conf");
+    const CONF: &str = include_str!("./dvbv5_channels_isdbs.conf");
 
-    let path_s = format!("/tmp/{name_s}");
-    let path_t = format!("/tmp/{name_t}");
+    // Use a unique file path per call to avoid races when multiple
+    // threads perform lookups concurrently.
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let path = format!(
+        "/tmp/dvbv5_channels_isdbs_{}_{}.conf",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    );
 
-    write!(File::create(&path_s).unwrap(), "{}", s).unwrap();
-    write!(File::create(&path_t).unwrap(), "{}", t).unwrap();
-
-    let s = FilePtr::new(
-        Path::new(&path_s),
+    let _guard = LOCK.lock().ok()?;
+    fs::write(&path, CONF).ok()?;
+    let entries = FilePtr::new(
+        Path::new(&path),
         Some(fe_delivery_system::SYS_ISDBS),
         Some(dvb_file_formats::FILE_DVBV5),
     )
-    .unwrap();
-    let t = FilePtr::new(
-        Path::new(&path_t),
-        Some(fe_delivery_system::SYS_ISDBS),
-        Some(dvb_file_formats::FILE_DVBV5),
-    )
-    .unwrap();
+    .ok()?;
+    let result = seek(entries, ch_name);
+    let _ = fs::remove_file(&path);
+    result
+}
 
-    (s, t)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_cs_tsid() {
+        assert_eq!(lookup_tsid("CS2"), Some(24608));
+        assert_eq!(lookup_tsid("CS4"), Some(28736));
+        assert_eq!(lookup_tsid("CS8"), Some(24704));
+        assert_eq!(lookup_tsid("CS24"), Some(29056));
+    }
+
+    #[test]
+    fn lookup_bs_tsid() {
+        assert_eq!(lookup_tsid("BS03_0"), Some(16432));
+        assert_eq!(lookup_tsid("BS01_0"), Some(16400));
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert_eq!(lookup_tsid("CS99"), None);
+        assert_eq!(lookup_tsid("BS99_0"), None);
+    }
 }


### PR DESCRIPTION
## 背景

少なくとも DD Max M2 利用時の環境において、CS を受信しようとすると巨大なストリームが流れ込んでハングアップしていると思しき事象を踏んでいたので修正したものです。

直したのがだいぶ前の話であまり覚えてなくて申し訳ないのですが、少なくとも手元だとそんな理由でハングするため、このパッチがないと CS の受信がまともに行えない状態だったのは確かです。（実際に前回の PR をマージいただいてこのパッチのことを忘れて upstream に戻したら CS が録画できなくなってて泣きました）

## 修正内容

CSチャンネルを --tsid 無指定で選局した場合、dvbv5_channels_isdbs.conf に TSID エントリが定義されているにもかかわらず、NO_STREAM_ID_FILTER が使われトランスポンダ全体(最大 12 スロット)の TS が流れ込んでいた。

table.rs に lookup_tsid() を新設し、CS AsIs 時にテーブルからトランスポンダの TSID を引いてフィルタするよう修正。
あわせて使用されていなかったコメントアウトコードの削除、libdvbv5 パーサのスレッド安全性確保のための Mutex 導入、CS/BS 両方の TSID ルックアップテストを追加。

---

チャンネル名の表記(CS02 vs CS2, BS3_0 vs BS03_0)がconfファイルのエントリ名と一致しない場合、ルックアップが失敗していた。

パース済みのチャンネル番号から正規名を構成してルックアップするよう変更。
CS02→CS2, BS3_0→BS03_0 のように正規化される。