### PR TITLE
ECM受信時に事業体識別番号をINFOログへ出力

### DIFF
--- a/b25-sys/src/bindings/ffi.rs
+++ b/b25-sys/src/bindings/ffi.rs
@@ -112,6 +112,10 @@ unsafe extern "C" fn proc_ecm(
         recv.to_vec()
     };
 
+    if payload.len() >= 2 {
+        info!("ECM broadcaster group ID: {}", payload[1]);
+    }
+
     let ks = {
         let size = payload.len();
         if size < 19 {


### PR DESCRIPTION
## 変更内容

- `block00cbc` の ECM 処理で、受信した ECM の事業体識別番号 (`broadcaster_group_id`) を INFO レベルで出力します。
- ECM が 2 バイト未満の場合はログ出力を行わず、既存の短い ECM に対するエラー処理へそのまま流します。

ログ例:

```text
ECM broadcaster group ID: 4
```

## 実装理由

ECM を受信した時点で事業体識別番号を確認できるようにし、放送事業体ごとの ECM の挙動をログから追跡しやすくします。

## 確認

- `master` との差分は `b25-sys/src/bindings/ffi.rs` の 4 行追加のみです。
- 実行環境から GitHub への直接 clone が DNS 制約で失敗したため、ローカルでの `cargo check` / `cargo fmt` は未実施です。追加コード自体は既存の `info!` import を利用し、rustfmt の整形を必要としない形にしています。